### PR TITLE
Update avatar.d.ts again (sorry!)

### DIFF
--- a/src/avatar.d.ts
+++ b/src/avatar.d.ts
@@ -113,17 +113,17 @@ export interface Props {
   /**
    * Invoked when user drag&drop event stop and return croped image in base64 sting
    */
-  onCrop?: (data: HTMLImageElement) => void;
+  onCrop?: (data: string) => void;
   
   /**
    * Invoked when user upload file with internal file loader
    */
-  onBeforeFileLoad?: (data: HTMLImageElement) => void;
+  onBeforeFileLoad?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 
   /**
    * Invoked when user upload file with internal file loader
    */
-  onFileLoad?: (data: HTMLImageElement) => void;
+  onFileLoad?: (data: React.ChangeEvent<HTMLInputElement> | File) => void;
 
   /**
    * Invoked when user clock on close editor button


### PR DESCRIPTION
Sorry I have just been looking through the code, and made some more type corrections: 

`onCrop` isn't expecting an image element, it is expecting a data url string, because it is set by getPreview() which returns a Konva toDataUrl function, returning a string
`onBeforeFileLoad` is actually getting passed a change event (I think??) so should be React.ChangeEvent<HTMLInputElement>
`onFileLoad` I _think_ ought to be a mixed type of File | React.ChangeEvent<HTMLInputElement>, because it is initially sent the event for input change (which it passes to onBeforeFileLoad) but then its callback passes the output of e.target.files[0] - This is the one I am a little unsure of to be honest!