### PR TITLE
Add support to export the image in a square format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4136,7 +4136,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -5769,7 +5770,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -9395,7 +9397,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/src/avatar.d.ts
+++ b/src/avatar.d.ts
@@ -60,6 +60,12 @@ export interface Props {
   minCropRadius?: number;
 
   /**
+   * When set to true the returned data for onCrop is a square instead of a circle.
+   * Default: false
+   */
+  returnCropAsSquare?: boolean;
+
+  /**
    * The color of the image background
    * Default: white
    */

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -18,6 +18,7 @@ class Avatar extends React.Component {
     closeIconColor: 'white',
     lineWidth: 4,
     minCropRadius: 30,
+    returnCropAsSquare: false,
     backgroundColor: 'grey',
     mimeTypes: 'image/jpeg,image/png',
     mobileScaleSpeed: 0.5, // experimental
@@ -280,7 +281,7 @@ class Avatar extends React.Component {
       resizeIcon.y(calcResizerY(y) - 10)
     };
 
-    const getPreview = () => crop.toDataURL({
+    const getPreview = () => (this.props.returnCropAsSquare ? background : crop).toDataURL({
       x: crop.x() - crop.radius(),
       y: crop.y() - crop.radius(),
       width: crop.radius() * 2,


### PR DESCRIPTION
This commits adds a prop that allows the export of the cropped image
through onCrop to be in a squared format of the cropped area.

This allows the storage of a squared image to be future-proof, when
deciding to use squared images instead of circular images.