### PR TITLE
Add support to export the image as JPEG

### DIFF
--- a/src/avatar.d.ts
+++ b/src/avatar.d.ts
@@ -90,6 +90,18 @@ export interface Props {
   mimeTypes?: string;
 
   /**
+   * The mime type used to generate the data param for onCrop
+   * Default: image/png
+   */
+  exportMimeType?: string;
+
+  /**
+   * The quality used to generate the data param for onCrop, only relevant for image/jpeg as exportMimeType
+   * Default: 1.0
+   */
+  exportQuality?: number;
+
+  /**
    * Label text
    * Default: Choose a file
    */

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -20,6 +20,8 @@ class Avatar extends React.Component {
     minCropRadius: 30,
     backgroundColor: 'grey',
     mimeTypes: 'image/jpeg,image/png',
+    exportMimeType: 'image/png',
+    exportQuality: 1.0,
     mobileScaleSpeed: 0.5, // experimental
     onClose: () => {
     },
@@ -284,7 +286,9 @@ class Avatar extends React.Component {
       x: crop.x() - crop.radius(),
       y: crop.y() - crop.radius(),
       width: crop.radius() * 2,
-      height: crop.radius() * 2
+      height: crop.radius() * 2,
+      mimeType: this.props.exportMimeType,
+      quality: this.props.exportQuality
     });
 
     const onScaleCallback = (scaleY) => {


### PR DESCRIPTION
This commit allows the returned image in onCrop to be an jpeg instead
of in a PNG format. This simplifies the workflow when working with
avatar images that should be in JPEG format.