### PR TITLE
Add export options to improve the returned image output

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ ReactDOM.render(<App /> , document.getElementById('root'))
 | onBeforeFileLoad(file) | Function         | Invoked when user before upload file with internal file loader (etc. check file size)
 | onFileLoad(file)       | Function         | Invoked when user upload file with internal file loader
 | onClose()              | Function         | Invoked when user clicks on close editor button
+| exportAsSquare         | Boolean          | The exported image is a square and the circle is not cut-off from the image
+| exportSize             | Number           | The size the exported image should have (width and height equal). The cropping will be made on the original image to ensure a high quality. Only supported when using "exportAsSquare"
+| exportMimeType         | String           | The mime type that should be used to export the image, supported are: image/jpeg, image/png (Default: image/png)
+| exportQuality          | Number           | The quality that should be used when exporting in image/jpeg. A value between 0.0 and 1.0.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4136,7 +4136,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -5769,7 +5770,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -9395,7 +9397,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/src/avatar.d.ts
+++ b/src/avatar.d.ts
@@ -60,6 +60,12 @@ export interface Props {
   minCropRadius?: number;
 
   /**
+   * When set to true the returned data for onCrop is a square instead of a circle.
+   * Default: false
+   */
+  returnCropAsSquare?: boolean;
+
+  /**
    * The color of the image background
    * Default: white
    */

--- a/src/avatar.d.ts
+++ b/src/avatar.d.ts
@@ -96,6 +96,18 @@ export interface Props {
   mimeTypes?: string;
 
   /**
+   * The mime type used to generate the data param for onCrop
+   * Default: image/png
+   */
+  exportMimeType?: string;
+
+  /**
+   * The quality used to generate the data param for onCrop, only relevant for image/jpeg as exportMimeType
+   * Default: 1.0
+   */
+  exportQuality?: number;
+
+  /**
    * Label text
    * Default: Choose a file
    */

--- a/src/avatar.d.ts
+++ b/src/avatar.d.ts
@@ -60,12 +60,6 @@ export interface Props {
   minCropRadius?: number;
 
   /**
-   * When set to true the returned data for onCrop is a square instead of a circle.
-   * Default: false
-   */
-  returnCropAsSquare?: boolean;
-
-  /**
    * The color of the image background
    * Default: white
    */
@@ -94,6 +88,18 @@ export interface Props {
    * Default: image/jpeg, image/png
    */
   mimeTypes?: string;
+
+  /**
+   * When set to true the returned data for onCrop is a square instead of a circle.
+   * Default: false
+   */
+  exportAsSquare?: boolean;
+
+  /**
+   * The number of pixels width/height should have on the exported image.
+   * Default: original size of the image
+   */
+  exportSize?: number;
 
   /**
    * The mime type used to generate the data param for onCrop

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -21,6 +21,8 @@ class Avatar extends React.Component {
     returnCropAsSquare: false,
     backgroundColor: 'grey',
     mimeTypes: 'image/jpeg,image/png',
+    exportMimeType: 'image/png',
+    exportQuality: 1.0,
     mobileScaleSpeed: 0.5, // experimental
     onClose: () => {
     },
@@ -285,7 +287,9 @@ class Avatar extends React.Component {
       x: crop.x() - crop.radius(),
       y: crop.y() - crop.radius(),
       width: crop.radius() * 2,
-      height: crop.radius() * 2
+      height: crop.radius() * 2,
+      mimeType: this.props.exportMimeType,
+      quality: this.props.exportQuality
     });
 
     const onScaleCallback = (scaleY) => {

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -18,6 +18,7 @@ class Avatar extends React.Component {
     closeIconColor: 'white',
     lineWidth: 4,
     minCropRadius: 30,
+    returnCropAsSquare: false,
     backgroundColor: 'grey',
     mimeTypes: 'image/jpeg,image/png',
     mobileScaleSpeed: 0.5, // experimental
@@ -280,7 +281,7 @@ class Avatar extends React.Component {
       resizeIcon.y(calcResizerY(y) - 10)
     };
 
-    const getPreview = () => crop.toDataURL({
+    const getPreview = () => (this.props.returnCropAsSquare ? background : crop).toDataURL({
       x: crop.x() - crop.radius(),
       y: crop.y() - crop.radius(),
       width: crop.radius() * 2,

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -18,9 +18,10 @@ class Avatar extends React.Component {
     closeIconColor: 'white',
     lineWidth: 4,
     minCropRadius: 30,
-    returnCropAsSquare: false,
     backgroundColor: 'grey',
     mimeTypes: 'image/jpeg,image/png',
+    exportAsSquare: false,
+    exportSize: undefined,
     exportMimeType: 'image/png',
     exportQuality: 1.0,
     mobileScaleSpeed: 0.5, // experimental
@@ -283,14 +284,37 @@ class Avatar extends React.Component {
       resizeIcon.y(calcResizerY(y) - 10)
     };
 
-    const getPreview = () => (this.props.returnCropAsSquare ? background : crop).toDataURL({
-      x: crop.x() - crop.radius(),
-      y: crop.y() - crop.radius(),
-      width: crop.radius() * 2,
-      height: crop.radius() * 2,
-      mimeType: this.props.exportMimeType,
-      quality: this.props.exportQuality
-    });
+    const getPreview = () => {
+      if(this.props.exportAsSquare) {
+        const fullSizeImage = new Konva.Image({ image: this.image });
+        const xScale = fullSizeImage.width() / background.width();
+        const yScale = fullSizeImage.height() / background.height();
+
+        const width = crop.radius() * 2 * xScale;
+        const height = crop.radius() * 2 * yScale;
+
+        const pixelRatio = this.props.exportSize ? this.props.exportSize / width : undefined;
+
+        return fullSizeImage.toDataURL({
+          x: (crop.x() - crop.radius()) * xScale,
+          y: (crop.y() - crop.radius())  * yScale,
+          width,
+          height,
+          pixelRatio,
+          mimeType: this.props.exportMimeType,
+          quality: this.props.exportQuality
+        });
+      } else {
+        return crop.toDataURL({
+          x: crop.x() - crop.radius(),
+          y: crop.y() - crop.radius(),
+          width: crop.radius() * 2,
+          height: crop.radius() * 2,
+          mimeType: this.props.exportMimeType,
+          quality: this.props.exportQuality
+        });
+      }
+    };
 
     const onScaleCallback = (scaleY) => {
       const scale = scaleY > 0 || isNotOutOfScale(scaleY) ? scaleY : 0;


### PR DESCRIPTION
- **Add support to export the image in a square format** (3428360)
  This commits adds a prop that allows the export of the cropped image through onCrop to be in a squared format of the cropped area.
  This allows the storage of a squared image to be future-proof, when deciding to use squared images instead of circular images.
- **Add support to export the image as JPEG** (5d0a36e)
  This commit allows the returned image in onCrop to be an jpeg instead of in a PNG format. This simplifies the workflow when working with avatar images that should be in JPEG format.
- **Add support to export images always in a prefered size** (9365157)
  This is helpful to ensure all profile images do have the same size. It also allows the exported images to be a higher quality to what is displayed in the circle.
- **Add documentation for the new options** (23f1d14)