### PR TITLE
Add pixelRatio to circle variant of preview.

### DIFF
--- a/example/app.jsx
+++ b/example/app.jsx
@@ -58,6 +58,7 @@ class App extends React.Component {
             <Avatar
               width={390}
               height={295}
+              exportSize={390}
               onCrop={this.onCropDefault}
               onClose={this.onCloseDefault}
               // src={this.state.src}

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -292,7 +292,6 @@ class Avatar extends React.Component {
 
         const width = crop.radius() * 2 * xScale;
         const height = crop.radius() * 2 * yScale;
-
         const pixelRatio = this.props.exportSize ? this.props.exportSize / width : undefined;
 
         return fullSizeImage.toDataURL({
@@ -305,11 +304,16 @@ class Avatar extends React.Component {
           quality: this.props.exportQuality
         });
       } else {
+        const width = crop.radius() * 2;
+        const height = crop.radius() * 2;
+        const pixelRatio = this.props.exportSize ? this.props.exportSize / width : undefined;
+
         return crop.toDataURL({
           x: crop.x() - crop.radius(),
           y: crop.y() - crop.radius(),
-          width: crop.radius() * 2,
-          height: crop.radius() * 2,
+          width,
+          height,
+          pixelRatio,
           mimeType: this.props.exportMimeType,
           quality: this.props.exportQuality
         });


### PR DESCRIPTION
@kirill3333 would it make sense to add `pixelRatio` inside the circle variant of preview? Otherwise we are only able to preserve the image quality in square variant.

Changes: 
* added `pixelRatio` to the  the circle variant inside `getPreview`

Before:
![image](https://user-images.githubusercontent.com/14996348/110251445-1d138e00-7f89-11eb-9f50-091d1135b35b.png)

After (with indicated exportSize):
![image](https://user-images.githubusercontent.com/14996348/110251425-05d4a080-7f89-11eb-9bf9-22380b5bc646.png)
