### PR TITLE
Allow React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "webpack-dev-server": "^4.3.0"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": "^16.x || ^17",
   }
 }


### PR DESCRIPTION
Update peerDependencies to allow for use of React 17 alongside React 16. This PR allows npm users to avoid having to force install (using `npm install --legacy-peer-deps`) on newer versions of npm