### PR TITLE
Fix unexpected token in JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "webpack-dev-server": "^4.3.0"
   },
   "peerDependencies": {
-    "react": "^16.x || ^17",
+    "react": ">=16.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "webpack-dev-server": "^4.3.0"
   },
   "peerDependencies": {
-    "react": ">=16.x"
+    "react": ">=16.x || ^17"
   }
 }

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -456,8 +456,8 @@ class Avatar extends React.Component {
     return new Konva.Rect({
       x: this.halfWidth + this.cropRadius * 0.86 - 8,
       y: this.halfHeight + this.cropRadius * -0.5 - 8,
-      width: 16,
-      height: 16,
+      width: 32,
+      height: 32,
       draggable: true,
       dragBoundFunc: function (pos) {
         return {


### PR DESCRIPTION
Pull #89 uses `||` in version which results in the error below. 
Changed react version syntax from `^16.x || ^17` to `>=16.x` to fix this issue.

```
npm ERR! JSON.parse Unexpected token "}" (0x7D) in JSON at position 1618 while parsing near "... \"^16.x || ^17\",\r\n  }\r\n}\r\n"
npm ERR! JSON.parse Failed to parse JSON data.
npm ERR! JSON.parse Note: package.json must be actual JSON, not just JavaScript.
```