### PR TITLE
Upgrade Konva to 8.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "blueimp-load-image": "^5.14.0",
         "exif-js": "^2.3.0",
-        "konva": "^2.5.1"
+        "konva": "^8.3.5"
       },
       "devDependencies": {
         "@babel/cli": "^7.12.1",
@@ -32,7 +32,7 @@
         "webpack-dev-server": "^4.3.0"
       },
       "peerDependencies": {
-        "react": "16.x"
+        "react": "^16.x || ^17"
       }
     },
     "node_modules/@babel/cli": {
@@ -6887,9 +6887,23 @@
       }
     },
     "node_modules/konva": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/konva/-/konva-2.5.1.tgz",
-      "integrity": "sha512-YdHEWqmbWPieqIZuLx7JFGm9Ui08hSUaSJ2k2Ml8o5giFgJ0WmxAS0DPXIM+Ty2ADRagOHZfXSJ/skwYqqlwgQ=="
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-8.3.5.tgz",
+      "integrity": "sha512-RjaZN8PwZN3n/AlqLmtPNozLRXd6pPo11UawTJpvuOAKEkSQSXI1EHntDRIPnrrJ/j4gU0VmPzWs7/ZgLZnAPQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ]
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -16121,9 +16135,9 @@
       }
     },
     "konva": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/konva/-/konva-2.5.1.tgz",
-      "integrity": "sha512-YdHEWqmbWPieqIZuLx7JFGm9Ui08hSUaSJ2k2Ml8o5giFgJ0WmxAS0DPXIM+Ty2ADRagOHZfXSJ/skwYqqlwgQ=="
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-8.3.5.tgz",
+      "integrity": "sha512-RjaZN8PwZN3n/AlqLmtPNozLRXd6pPo11UawTJpvuOAKEkSQSXI1EHntDRIPnrrJ/j4gU0VmPzWs7/ZgLZnAPQ=="
     },
     "leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "blueimp-load-image": "^5.14.0",
     "exif-js": "^2.3.0",
-    "konva": "^2.5.1"
+    "konva": "^8.3.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import Konva from 'konva/src/Core'
+import Konva from 'konva/lib/Core'
 import EXIF from 'exif-js'
 import LoadImage from 'blueimp-load-image'
-import 'konva/src/shapes/Image'
-import 'konva/src/shapes/Circle'
-import 'konva/src/shapes/Rect'
-import 'konva/src/shapes/Path'
-import 'konva/src/Animation'
-import 'konva/src/DragAndDrop'
+import 'konva/lib/shapes/Image'
+import 'konva/lib/shapes/Circle'
+import 'konva/lib/shapes/Rect'
+import 'konva/lib/shapes/Path'
+import 'konva/lib/Animation'
+import 'konva/lib/DragAndDrop'
 
 class Avatar extends React.Component {
 


### PR DESCRIPTION
We did this upgrade because we had problems (https://github.com/konvajs/react-konva/issues/253) with including the react-avatar dependency multiple times. The latest Konva version solves this issue. 