### PR TITLE
Use updated exif-js library

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/kirill3333/react-avatar#readme",
   "dependencies": {
     "blueimp-load-image": "^5.14.0",
-    "exif-js": "^2.3.0",
+    "exif-js_fixed": "^2.3.0",
     "konva": "^8.3.5"
   },
   "devDependencies": {

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Konva from 'konva/lib/Core'
-import EXIF from 'exif-js'
+import EXIF from 'exif-js_fixed'
 import LoadImage from 'blueimp-load-image'
 import 'konva/lib/shapes/Image'
 import 'konva/lib/shapes/Circle'


### PR DESCRIPTION
Fix `n is not defined` / `assignment to undeclared variable n` error because exif-js in not up to date on npm. https://www.npmjs.com/package/exif-js_fixed is pointing on the same repo [github.com/exif-js/exif-js](https://github.com/exif-js/exif-js) but updated with the correct variable declaration.